### PR TITLE
CI: Test against recent Go toolchain versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,9 @@ jobs:
         go-version:
         - 1.15
         - 1.16
+        - 1.17
+        - 1.18
+        - 1.19
         os:
         - ubuntu-latest
         - windows-latest

--- a/scan/run_test.go
+++ b/scan/run_test.go
@@ -374,7 +374,7 @@ func Test__inaccessible_internal_dir_is_logged(t *testing.T) {
 	res, err := Run(root, NoSkip, nil)
 	require.NoError(t, err)
 	assert.Equal(t, want, res)
-	assert.Equal(t, fmt.Sprintf("skipping inaccessible directory %q\n", d), buf.String())
+	assert.Equal(t, fmt.Sprintf("skipping inaccessible directory %q\n", filepath.Clean(d)), buf.String())
 }
 
 func Test__testdata_cache_with_mismatching_root_fails(t *testing.T) {


### PR DESCRIPTION
Include versions 1.17 through 1.19 such that all "supported" versions are included.