### PR TITLE
Various minor cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - "1.15"
         - "1.16"
         - "1.17"
         - "1.18"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,16 +10,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: "1.20"
+        go-version: "1.22"
         cache: true
 
     - name: Install goimports
-      run: go install golang.org/x/tools/cmd/goimports@v0.6.0
+      run: go install golang.org/x/tools/cmd/goimports@v0.17.0
 
     - name: Run goimports and fail if it reports anything
       run: |
@@ -35,7 +35,7 @@ jobs:
       run: go vet ./...
 
     - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.2
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
 
     - name: Run staticcheck
       run: staticcheck ./...
@@ -65,10 +65,10 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: "${{ matrix.go-version }}"
         cache: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,8 @@ jobs:
         - "1.18"
         - "1.19"
         - "1.20"
+        - "1.21"
+        - "1.22"
         os:
         - ubuntu-latest
         - windows-latest

--- a/cmd/dupe-nukem/hash_test.go
+++ b/cmd/dupe-nukem/hash_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -39,7 +38,7 @@ func Test__hash_wraps_file_error(t *testing.T) {
 	// This test is basically identical to 'Test__hash_inaccessible_file_fails' (in package 'hash'),
 	// but, as indicated by the test name, the purpose is slightly different:
 	// Hashing an inaccessible file just happens to be the easiest way to trigger an error.
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	filename := f.Name()
 	defer func() {

--- a/cmd/dupe-nukem/main.go
+++ b/cmd/dupe-nukem/main.go
@@ -9,15 +9,15 @@ import (
 )
 
 func main() {
-	// ANNOYANCE The description of cobra's default help command is upper case and cannot be changed
-	//           without doing the whole command ourselves (inconsistently, flags are lower case!).
-	//           So for now we follow the same convention.
-	//           Consider vendoring or finding a replacement for this library to fix this
-	//           and also get rid of all of its irrelevant dependencies.
-	// IDEA Require output file as a parameter rather than just using stdout.
-	//      Use the filename or an additional flag to add compression.
-	//      Use another flag to specify encryption password.
-	//      Also output a file with a cryptographic hash of the data structure (or include in the file?).
+	// ANNOYANCE: The description of cobra's default help command is upper case and cannot be changed
+	//            without doing the whole command ourselves (inconsistently, flags are lower case!).
+	//            So for now we follow the same convention.
+	//            Consider vendoring or finding a replacement for this library to fix this
+	//            and also get rid of all of its irrelevant dependencies.
+	// IDEA: Require output file as a parameter rather than just using stdout.
+	//       Use the filename or an additional flag to add compression.
+	//       Use another flag to specify encryption password.
+	//       Also output a file with a cryptographic hash of the data structure (or include in the file?).
 	rootCmd := &cobra.Command{Use: "dupe-nukem", SilenceUsage: true, SilenceErrors: true}
 	hashCmd := &cobra.Command{
 		Use:   "hash",

--- a/cmd/dupe-nukem/scan.go
+++ b/cmd/dupe-nukem/scan.go
@@ -59,7 +59,7 @@ func loadShouldSkip(expr string) (scan.ShouldSkipPath, error) {
 }
 
 func parseSkipNames(input string) ([]string, error) {
-	if input == "" {
+	if len(input) == 0 {
 		return nil, nil
 	}
 	if input[0] == '@' {
@@ -71,7 +71,7 @@ func parseSkipNames(input string) ([]string, error) {
 }
 
 func parseSkipNameFile(path string) ([]string, error) {
-	// TODO Pass 'open' function (see comment in 'loadScanDirFile').
+	// TODO: Pass 'open' function (see comment in 'loadScanDirFile').
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(util.SimplifyIOError(err), "cannot open file")
@@ -130,7 +130,7 @@ func loadScanDirCacheFile(path string) (*scan.Dir, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO Unless it's too expensive, just sort lists instead of only validating?
+	// TODO: Unless it's too expensive, just sort lists instead of only validating?
 	if err := checkCache(scanDir); err != nil {
 		return nil, errors.Wrap(err, "invalid cache contents")
 	}

--- a/cmd/dupe-nukem/scan_test.go
+++ b/cmd/dupe-nukem/scan_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,7 +39,7 @@ func Test__parseSkipNames_with_at_prefix_splits_file_on_newline(t *testing.T) {
 }
 
 func Test__parseSkipNames_file_with_length_255_is_allowed(t *testing.T) {
-	f, err := ioutil.TempFile("", "allowed-skipnames")
+	f, err := os.CreateTemp("", "allowed-skipnames")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -65,7 +64,7 @@ func Test__parseSkipNames_file_with_length_255_is_allowed(t *testing.T) {
 // in the valid cases.
 
 func Test__loadShouldSkip_file_with_length_256_fails(t *testing.T) {
-	f, err := ioutil.TempFile("", "long-skipnames")
+	f, err := os.CreateTemp("", "long-skipnames")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -83,7 +82,7 @@ func Test__loadShouldSkip_file_with_length_256_fails(t *testing.T) {
 }
 
 func Test__loadShouldSkip_file_with_invalid_line_fails(t *testing.T) {
-	f, err := ioutil.TempFile("", "invalid-skipnames")
+	f, err := os.CreateTemp("", "invalid-skipnames")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -162,7 +161,7 @@ func Test__loadScanDirCacheFile_logs_nonexistent_file_before_loading(t *testing.
 }
 
 func Test__loadScanDirCacheFile_wraps_invalid_cache_error(t *testing.T) {
-	f, err := ioutil.TempFile("", "invalid")
+	f, err := os.CreateTemp("", "invalid")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -195,7 +194,7 @@ func Test__Scan_wraps_cache_file_not_found_error(t *testing.T) {
 }
 
 func Test__Scan_wraps_cache_file_not_accessible_error(t *testing.T) {
-	f, err := ioutil.TempFile("", "inaccessible")
+	f, err := os.CreateTemp("", "inaccessible")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -210,7 +209,7 @@ func Test__Scan_wraps_cache_file_not_accessible_error(t *testing.T) {
 }
 
 func Test__Scan_wraps_cache_load_error(t *testing.T) {
-	f, err := ioutil.TempFile("", "malformed")
+	f, err := os.CreateTemp("", "malformed")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -326,7 +325,7 @@ func Test__checkCache_logs_warning_on_hash_0(t *testing.T) {
 	assert.Equal(t, "warning: file \"a\" is cached with hash 0 - this hash will be ignored\n", buf.String())
 }
 
-// TODO Add test that demonstrates that the cache is loaded/used by letting the cache data *not* match the actual files.
+// TODO: Add test that demonstrates that the cache is loaded/used by letting the cache data *not* match the actual files.
 
 func Test__scan_testdata(t *testing.T) {
 	root := "testdata"

--- a/cmd/dupe-nukem/shared.go
+++ b/cmd/dupe-nukem/shared.go
@@ -16,7 +16,7 @@ import (
 )
 
 func resolveReader(f *os.File) (io.Reader, error) {
-	// TODO Read magic number instead of extension.
+	// TODO: Read magic number instead of extension.
 	if strings.HasSuffix(f.Name(), ".gz") {
 		return gzip.NewReader(f)
 	}
@@ -24,7 +24,7 @@ func resolveReader(f *os.File) (io.Reader, error) {
 }
 
 func loadScanDirFile(path string) (*scan.Dir, error) {
-	// TODO Pass in 'open' function to enable tests to return error, create fake file, disallow closing, etc.
+	// TODO: Pass in 'open' function to enable tests to return error, create fake file, disallow closing, etc.
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrap(util.SimplifyIOError(err), "cannot open file")

--- a/cmd/dupe-nukem/shared_test.go
+++ b/cmd/dupe-nukem/shared_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 )
 
 func Test__resolveReader_rejects_invalid_compressed_scan_file(t *testing.T) {
-	f, err := ioutil.TempFile("", "invalid-*.gz") // the '*' is swapped out for gibberish instead of it being appended after the '.gz'
+	f, err := os.CreateTemp("", "invalid-*.gz") // the '*' is swapped out for gibberish instead of it being appended after the '.gz'
 	require.NoError(t, err)
 	defer func() {
 		err := f.Close()
@@ -60,7 +59,7 @@ func Test__loadScanDirFile_loads_compressed_scan_file(t *testing.T) {
 }
 
 func Test__loadScanDirFile_wraps_scan_file_error(t *testing.T) {
-	f, err := ioutil.TempFile("", "invalid-*.gz") // the '*' is swapped out for gibberish instead of it being appended after the '.gz'
+	f, err := os.CreateTemp("", "invalid-*.gz") // the '*' is swapped out for gibberish instead of it being appended after the '.gz'
 	require.NoError(t, err)
 	defer func() {
 		err := f.Close()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bisgardo/dupe-nukem
 
-go 1.15
+go 1.16
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -3,7 +3,6 @@ package hash
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -28,7 +27,7 @@ func Test__hash_file(t *testing.T) {
 	assert.Equal(t, uint64(644258871406045975), res)
 }
 
-// TODO Test other kinds of (broken) files.
+// TODO: Test other kinds of (broken) files.
 func Test__hash_dir_fails(t *testing.T) {
 	_, err := File("testdata")
 
@@ -50,7 +49,7 @@ func Test__hash_dir_fails(t *testing.T) {
 func Test__hash_inaccessible_file_fails(t *testing.T) {
 	// This test is basically identical to 'Test__hash_wraps_file_error' (in package 'main'),
 	// but the purpose is slightly different (as indicated by the test name).
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 	filename := f.Name()
 	defer func() {

--- a/scan/file.go
+++ b/scan/file.go
@@ -62,7 +62,7 @@ func (d *Dir) appendSkippedDir(dirName string) {
 	d.SkippedDirs = append(d.SkippedDirs, dirName)
 }
 
-// TODO Add function for validating (or ensuring?) that the lists are indeed ordered correctly.
+// TODO: Add function for validating (or ensuring?) that the lists are indeed ordered correctly.
 
 // File represents a file as a name, size, and fnv hash.
 type File struct {
@@ -81,12 +81,12 @@ func NewFile(name string, size int64, hash uint64) *File {
 }
 
 // safeFindDir looks for a Dir with the given name in the subdirectory list of the given Dir.
-// Returns nil if the Dir is nil.
+// Returns nil if the Dir is nil or doesn't have a subdirectory with that name.
 func safeFindDir(d *Dir, name string) *Dir {
 	if d == nil {
 		return nil
 	}
-	// TODO Use binary search.
+	// TODO: Use binary search.
 	for _, s := range d.Dirs {
 		if s.Name == name {
 			return s
@@ -96,12 +96,12 @@ func safeFindDir(d *Dir, name string) *Dir {
 }
 
 // safeFindFile looks for a File with the given name in the file list of the given Dir.
-// Returns nil if the Dir is nil.
+// Returns nil if the Dir is nil or doesn't have a file with that name.
 func safeFindFile(d *Dir, name string) *File {
 	if d == nil {
 		return nil
 	}
-	// TODO Use binary search.
+	// TODO: Use binary search.
 	for _, f := range d.Files {
 		if f.Name == name {
 			return f

--- a/scan/file_test.go
+++ b/scan/file_test.go
@@ -72,7 +72,7 @@ func Test__safeFindDir_finds_subdir(t *testing.T) {
 		{dir: testDir_y, name: "x", want: nil},               // doesn't find parent
 		{dir: testDir_y, name: "z", want: testDir_z},         // finds single subdir
 		{dir: testDir_z, name: "", want: nil},                // has no subdirs
-		{dir: testDir_z, name: "", want: nil},                // has no subdirs
+		{dir: testDir_z, name: "s", want: nil},               // has no subdirs
 		{dir: testDir_r, name: "s", want: testDir_r.Dirs[0]}, // finds subdir 1/2 (empty)
 		{dir: testDir_r, name: "t", want: testDir_r.Dirs[1]}, // finds subdir 2/2 (no subdirs)
 	}

--- a/scan/file_test.go
+++ b/scan/file_test.go
@@ -61,14 +61,20 @@ func Test__safeFindDir_finds_subdir(t *testing.T) {
 		name string
 		want *Dir
 	}{
-		{dir: testDir_x, name: "x", want: nil},
-		{dir: testDir_x, name: "y", want: testDir_y},
-		{dir: testDir_x, name: "r", want: testDir_r},
-		{dir: testDir_y, name: "y", want: nil},
-		{dir: testDir_y, name: "z", want: testDir_z},
-		{dir: testDir_z, name: "", want: nil},
-		{dir: testDir_r, name: "s", want: testDir_r.Dirs[0]},
-		{dir: testDir_r, name: "t", want: testDir_r.Dirs[1]},
+		{dir: testDir_x, name: "", want: nil},                // doesn't find garbage
+		{dir: testDir_x, name: "nonexistent", want: nil},     // doesn't find other garbage
+		{dir: testDir_x, name: "x", want: nil},               // doesn't find dir
+		{dir: testDir_x, name: "y", want: testDir_y},         // finds subdir 1/2
+		{dir: testDir_x, name: "r", want: testDir_r},         // finds subdir 2/2
+		{dir: testDir_x, name: "z", want: nil},               // doesn't find nested subdir
+		{dir: testDir_x, name: "a", want: nil},               // doesn't find file
+		{dir: testDir_x, name: "s", want: nil},               // doesn't find nested file (in "r")
+		{dir: testDir_y, name: "x", want: nil},               // doesn't find parent
+		{dir: testDir_y, name: "z", want: testDir_z},         // finds single subdir
+		{dir: testDir_z, name: "", want: nil},                // has no subdirs
+		{dir: testDir_z, name: "", want: nil},                // has no subdirs
+		{dir: testDir_r, name: "s", want: testDir_r.Dirs[0]}, // finds subdir 1/2 (empty)
+		{dir: testDir_r, name: "t", want: testDir_r.Dirs[1]}, // finds subdir 2/2 (no subdirs)
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v/%v", test.dir.Name, test.name), func(t *testing.T) {
@@ -84,18 +90,13 @@ func Test__safeFindFile_finds_file(t *testing.T) {
 		name string
 		want *File
 	}{
-		{dir: testDir_x, name: "x", want: nil},
-		{dir: testDir_x, name: "a", want: testDir_x.Files[0]},
-		{dir: testDir_x, name: "b", want: testDir_x.Files[1]},
-		{dir: testDir_x, name: "c", want: testDir_x.Files[2]},
-
-		{dir: testDir_y, name: "y", want: nil},
-		{dir: testDir_y, name: "r", want: testDir_y.Files[0]},
-		{dir: testDir_y, name: "s", want: testDir_y.Files[1]},
-
-		{dir: testDir_z, name: "", want: nil},
-		{dir: testDir_z, name: "a", want: testDir_z.Files[0]},
-		{dir: testDir_z, name: "b", want: testDir_z.Files[1]},
+		{dir: testDir_x, name: "", want: nil},                 // doesn't find garbage
+		{dir: testDir_x, name: "nonexistent", want: nil},      // doesn't find other garbage
+		{dir: testDir_x, name: "x", want: nil},                // doesn't find dir
+		{dir: testDir_x, name: "y", want: nil},                // doesn't find subdir
+		{dir: testDir_x, name: "a", want: testDir_x.Files[0]}, // finds file 1/3
+		{dir: testDir_x, name: "b", want: testDir_x.Files[1]}, // finds file 2/3
+		{dir: testDir_x, name: "c", want: testDir_x.Files[2]}, // finds file 3/3
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v/%v", test.dir.Name, test.name), func(t *testing.T) {

--- a/scan/run_test.go
+++ b/scan/run_test.go
@@ -2,7 +2,6 @@ package scan
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,13 +15,13 @@ import (
 
 // Working dir for tests is the directory containing the file.
 
-// TODO Figure out how to test symlinks on Windows:
-//      - Create specialized tests that need to be run manually as administrator.
-//      - Handle/test Windows-specific features: shortcuts, junctions.
-// TODO Test logged output whenever it's relevant.
+// TODO: Figure out how to test symlinks on Windows:
+//       - Create specialized tests that need to be run manually as administrator.
+//       - Handle/test Windows-specific features: shortcuts, junctions.
+// TODO: Test logged output whenever it's relevant.
 
 func Test__empty_dir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "empty")
+	dir, err := os.MkdirTemp("", "empty")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(dir)
@@ -61,7 +60,7 @@ func Test__nonexistent_dir_fails(t *testing.T) {
 }
 
 func Test__file_root_fails(t *testing.T) {
-	f, err := ioutil.TempFile("", "root")
+	f, err := os.CreateTemp("", "root")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -88,7 +87,7 @@ func Test__inaccessible_root_is_skipped(t *testing.T) {
 	if testutil.CI() == "github" && runtime.GOOS != "linux" {
 		return // skip test
 	}
-	d, err := ioutil.TempDir("", "inaccessible")
+	d, err := os.MkdirTemp("", "inaccessible")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(d)
@@ -316,7 +315,7 @@ func Test__testdata_trailing_slash_gets_removed(t *testing.T) {
 
 // On Windows, this test only works if the repository is stored on an NTFS drive.
 func Test__inaccessible_internal_file_is_not_hashed_and_is_logged(t *testing.T) {
-	f, err := ioutil.TempFile("testdata/e/f", "inaccessible")
+	f, err := os.CreateTemp("testdata/e/f", "inaccessible")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())
@@ -354,7 +353,7 @@ func Test__inaccessible_internal_file_is_not_hashed_and_is_logged(t *testing.T) 
 
 // On Windows, this test only works if the repository is stored on an NTFS drive.
 func Test__inaccessible_internal_dir_is_logged(t *testing.T) {
-	d, err := ioutil.TempDir("testdata/e/f", "inaccessible")
+	d, err := os.MkdirTemp("testdata/e/f", "inaccessible")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(d)
@@ -493,7 +492,7 @@ func Test__cache_entry_with_hash_0_is_ignored(t *testing.T) {
 }
 
 // DISABLED on Windows and macOS (on GitHub) for the same reasons as 'Test__inaccessible_root_is_skipped'.
-// TODO Why is this test so complex? Does/should it test more than just logging?
+// TODO: Why is this test so complex? Does/should it test more than just logging?
 func Test__hash_computed_as_0_is_logged(t *testing.T) {
 	//goland:noinspection GoBoolExpressions
 	if testutil.CI() == "github" && runtime.GOOS != "linux" {
@@ -502,14 +501,14 @@ func Test__hash_computed_as_0_is_logged(t *testing.T) {
 
 	v := "77kepQFQ8Kl" // from 'https://md5hashing.net/hash/fnv1a64/0000000000000000'
 
-	d, err := ioutil.TempDir("", "hash0")
+	d, err := os.MkdirTemp("", "hash0")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(d)
 		assert.NoError(t, err)
 	}()
 
-	f, err := ioutil.TempFile(d, "hash0")
+	f, err := os.CreateTemp(d, "hash0")
 	require.NoError(t, err)
 	defer func() {
 		err := os.Remove(f.Name())

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO Use build flags instead of checking OS on runtime?
-// TODO Should ideally return cleanup function for reverting the change?
+// TODO: Use build flags instead of checking OS on runtime?
+// TODO: Should ideally return cleanup function for reverting the change?
 
 // MakeFileInaccessible makes the provided file non-readable to the user
 // running the test.


### PR DESCRIPTION
- Bump versions of CI actions.
- Replace calls to deprecated functions for creating temporary files and dirs. This forces us to drop support for Go 1.15 and below. Go 1.16 was released in Feb 2021.
- Minor improvements to comments.