### PR TITLE
scan: Make more characters invalid to use in skip expressions

### DIFF
--- a/cmd/dupe-nukem/scan_test.go
+++ b/cmd/dupe-nukem/scan_test.go
@@ -91,6 +91,17 @@ func Test__loadShouldSkip_invalid_names_fail(t *testing.T) {
 	}
 }
 
+func Test__backslash_is_invalid_in_skip_name_on_windows_only(t *testing.T) {
+	_, containsBackslash := invalidSkipNameChars['\\']
+	assert.Equal(t, runtime.GOOS == "windows", containsBackslash)
+	assert.Contains(t, invalidSkipNameChars, '/') // '/' is invalid on all systems
+}
+
+func Test__regex_characters_are_invalid_in_skip_name(t *testing.T) {
+	assert.Contains(t, invalidSkipNameChars, '*')
+	assert.Contains(t, invalidSkipNameChars, '?')
+}
+
 func Test__Scan_wraps_skip_file_not_found_error(t *testing.T) {
 	_, err := Scan("x", "@missing", "")
 	assert.EqualError(t, err, `cannot process skip dirs expression "@missing": cannot read skip names from file "missing": cannot open file: not found`)

--- a/scan/run_test.go
+++ b/scan/run_test.go
@@ -309,6 +309,7 @@ func Test__trailing_slash_of_run_path_gets_removed(t *testing.T) {
 }
 
 // On Windows, this test only works if the repository is stored on an NTFS drive.
+// TODO: Detect and skip based on the above (something like testutil.UsesInaccessible(t) - which we can then assert against).
 func Test__inaccessible_internal_file_is_not_hashed_and_is_logged(t *testing.T) {
 	root := dir{
 		"a":            file{c: "z\n"},


### PR DESCRIPTION
We reject characters that have a common special meaning in relation to certain features, while being very uncommon (or even invalid) in file names:

- OS-specific path separator (in addition to `/` which is already invalid): Ensure that `\` isn't used on Windows. The purpose of rejecting these is to avoid giving the user the impression that nested paths are supported.

- `*` and `?`: Their usage is an indicator that the user intended to use regex/glob expressions. It's likely that we're going to support such expressions in the future.