### PR TITLE
scan: Ignore skipping of root

### DIFF
--- a/scan/run.go
+++ b/scan/run.go
@@ -41,9 +41,6 @@ func SkipNameSet(names map[string]struct{}) ShouldSkipPath {
 // - The root is an existing directory.
 func Run(root string, shouldSkip ShouldSkipPath, cache *Dir) (*Dir, error) {
 	rootName := filepath.Base(root)
-	if shouldSkip(filepath.Dir(root), rootName) {
-		return nil, fmt.Errorf("skipping root directory %q", root)
-	}
 	if cache != nil && cache.Name != rootName {
 		// While there's no technical reason for this requirement,
 		// it seems reasonable that differing root names would signal a mistake in most cases.
@@ -82,6 +79,10 @@ func validateRoot(path string) error {
 // run runs the "scan" command without any sanity checks.
 // In particular, the directory must not have a trailing slash as that will cause the file walk to panic.
 func run(rootName, root string, shouldSkip ShouldSkipPath, cache *Dir) (*Dir, error) {
+	if shouldSkip(filepath.Dir(root), filepath.Base(root)) {
+		log.Printf("not skipping root directory %q", root)
+	}
+
 	type walkContext struct {
 		prev     *walkContext
 		curDir   *Dir

--- a/scan/testdata_test.go
+++ b/scan/testdata_test.go
@@ -93,7 +93,7 @@ func (d dir) writeTestdata(t *testing.T, path string) {
 // dirExt is an extension of dir that adds the ability
 // to expect the directory to be skipped or made inaccessible.
 type dirExt struct {
-	dir          dir
+	dir
 	skipped      bool
 	inaccessible bool
 }
@@ -192,12 +192,25 @@ func (s symlink) writeTestdata(t *testing.T, path string) {
 	require.NoErrorf(t, err, "cannot create symlink with value %q at path %q", s, path)
 }
 
+type symlinkExt struct {
+	symlink
+	skipped bool
+}
+
+func (s symlinkExt) simulateScanFromParent(dir *Dir, name string) {
+	if s.skipped {
+		dir.appendSkippedFile(name)
+	}
+	s.symlink.simulateScanFromParent(dir, name)
+}
+
 // Verify conformance to node interface.
 var (
 	_ node = dir{}
 	_ node = dirExt{}
 	_ node = file{}
 	_ node = symlink("")
+	_ node = symlinkExt{}
 )
 
 func Test__node(t *testing.T) {

--- a/testutil/log.go
+++ b/testutil/log.go
@@ -7,6 +7,7 @@ import (
 )
 
 // CollectLogs returns a collector of logs emitted with the [log] package.
+// TODO: Restore output in cleanup function?
 func CollectLogs() fmt.Stringer {
 	var buf bytes.Buffer
 	log.SetFlags(0)


### PR DESCRIPTION
Instead of failing with an error when the skip list includes the root, we now just log that it isn't going to be skipped.

If the root is a symlink, then skipping applies to its target. The symlink resolution is logged separately, so this should not be a source of surprise.