### PR TITLE
Fix linter

### DIFF
--- a/.github/workflows/lint+test.yaml
+++ b/.github/workflows/lint+test.yaml
@@ -44,7 +44,7 @@ jobs:
       run: go install golang.org/x/lint/golint@latest
 
     - name: Run golint
-      run: golint -min_confidence 1 ./...
+      run: golint -set_exit_status -min_confidence 1 ./...
 
   test:
     strategy:

--- a/testutil/string.go
+++ b/testutil/string.go
@@ -2,6 +2,7 @@ package testutil
 
 import "bytes"
 
+// Lines concatenates the provided strings after adding a newline after each of them.
 func Lines(s ...string) string {
 	var buf bytes.Buffer
 	for _, l := range s {


### PR DESCRIPTION
Add docstring as demanded by linter and make CI workflow fail whenever violations are reported.